### PR TITLE
Image maps

### DIFF
--- a/samples/ayunami2000/VideoMapPacketCodec.java
+++ b/samples/ayunami2000/VideoMapPacketCodec.java
@@ -174,7 +174,7 @@ public class VideoMapPacketCodec {
 	/**
 	 * @param url URL to an MP4 or other HTML5 supported video file
 	 * @param loop If the video file should loop
-	 * @param durationSeconds duration of the video in seconds
+	 * @param duration duration of the video in seconds
 	 * @return packet to send to players
 	 */
 	public byte[] beginPlayback(String url, boolean loop, float duration) {

--- a/samples/ayunami2000/VideoMapPacketCodec.java
+++ b/samples/ayunami2000/VideoMapPacketCodec.java
@@ -40,7 +40,7 @@ public class VideoMapPacketCodec {
 		this.requiresFullResetPacket = true;
 		this.isDisabled = true;
 	}
-	
+
 	/**
 	 * @param mapIds 2D grid of map IDs that make up the screen (mapIds[y][x])
 	 * @param posX audio playback X coord
@@ -48,7 +48,14 @@ public class VideoMapPacketCodec {
 	 * @param posZ audio playback Z coord
 	 */
 	public VideoMapPacketCodec(int[][] mapIds, double posX, double posY, double posZ) {
-		this(mapIds, posX, posY, posZ, 1.0f);
+		this(mapIds, posX, posY, posZ, 0.5f);
+	}
+
+	/**
+	 * @param mapIds 2D grid of map IDs that make up the screen (mapIds[y][x])
+	 */
+	public VideoMapPacketCodec(int[][] mapIds) {
+		this(mapIds, 0, 100, 0, 0.5f);
 	}
 
 	/**

--- a/samples/ayunami2000/VideoMapPacketCodecBukkit.java
+++ b/samples/ayunami2000/VideoMapPacketCodecBukkit.java
@@ -20,7 +20,7 @@ public class VideoMapPacketCodecBukkit extends VideoMapPacketCodec {
 	public VideoMapPacketCodecBukkit(int[][] mapIds, double posX, double posY, double posZ, float volume) {
 		super(mapIds, posX, posY, posZ, volume);
 	}
-	
+
 	/**
 	 * @param mapIds 2D grid of map IDs that make up the screen (mapIds[y][x])
 	 * @param posX audio playback X coord
@@ -28,13 +28,23 @@ public class VideoMapPacketCodecBukkit extends VideoMapPacketCodec {
 	 * @param posZ audio playback Z coord
 	 */
 	public VideoMapPacketCodecBukkit(int[][] mapIds, double posX, double posY, double posZ) {
-		super(mapIds, posX, posY, posZ, 1.0f);
+		super(mapIds, posX, posY, posZ);
+	}
+
+	/**
+	 * @param mapIds 2D grid of map IDs that make up the screen (mapIds[y][x])
+	 */
+	public VideoMapPacketCodecBukkit(int[][] mapIds) {
+		super(mapIds);
 	}
 	
 	public static class VideoMapPacket {
 		protected final Object packet;
 		protected VideoMapPacket(byte[] packet) {
-			this.packet = new Packet131ItemData((short)104, (short)0, packet);
+			this(packet, false);
+		}
+		protected VideoMapPacket(byte[] packet, boolean image) {
+			this.packet = new Packet131ItemData((short)(104 + (image ? 1 : 0)), (short)0, packet);
 		}
 		public Object getNativePacket() {
 			return packet;
@@ -72,7 +82,15 @@ public class VideoMapPacketCodecBukkit extends VideoMapPacketCodec {
 	public VideoMapPacket disableVideoBukkit() {
 		return new VideoMapPacket(disableVideo());
 	}
-	
+
+	/**
+	 * unloads image and resets all map object to vanilla renderer
+	 * @return packet to send to players
+	 */
+	public VideoMapPacket disableImageBukkit() {
+		return new VideoMapPacket(disableVideo(), true);
+	}
+
 	/**
 	 * syncs the server side video timestamp with players
 	 * @return packet to send to players
@@ -80,7 +98,15 @@ public class VideoMapPacketCodecBukkit extends VideoMapPacketCodec {
 	public VideoMapPacket syncPlaybackWithPlayersBukkit() {
 		return new VideoMapPacket(syncPlaybackWithPlayers());
 	}
-	
+
+	/**
+	 * syncs the server side image with players
+	 * @return packet to send to players
+	 */
+	public VideoMapPacket syncPlaybackWithPlayersImageBukkit() {
+		return new VideoMapPacket(syncPlaybackWithPlayers(), true);
+	}
+
 	/**
 	 * @param url URL to an MP4 or other HTML5 supported video file
 	 * @param loop If the video file should loop
@@ -90,7 +116,15 @@ public class VideoMapPacketCodecBukkit extends VideoMapPacketCodec {
 	public VideoMapPacket beginPlaybackBukkit(String url, boolean loop, float duration) {
 		return new VideoMapPacket(beginPlayback(url, loop, duration));
 	}
-	
+
+	/**
+	 * @param url URL to a PNG, JPEG, GIF, or other HTML5 supported image file
+	 * @return packet to send to players
+	 */
+	public VideoMapPacket beginPlaybackImageBukkit(String url) {
+		return new VideoMapPacket(beginPlayback(url, loop, duration));
+	}
+
 	/**
 	 * Tells the browser to pre-load a URL to a video to be played in the future
 	 * @param url the URL of the video
@@ -99,6 +133,16 @@ public class VideoMapPacketCodecBukkit extends VideoMapPacketCodec {
 	 */
 	public static VideoMapPacket bufferVideoBukkit(String url, int ttl) {
 		return new VideoMapPacket(bufferVideo(url, ttl));
+	}
+
+	/**
+	 * Tells the browser to pre-load a URL to an image to be played in the future
+	 * @param url the URL of the image
+	 * @param ttl the amount of time the image should stay loaded
+	 * @return packet to send to players
+	 */
+	public static VideoMapPacket bufferImageBukkit(String url, int ttl) {
+		return new VideoMapPacket(bufferVideo(url, ttl), true);
 	}
 
 	/**

--- a/samples/ayunami2000/VideoMapPacketCodecBukkit.java
+++ b/samples/ayunami2000/VideoMapPacketCodecBukkit.java
@@ -122,7 +122,7 @@ public class VideoMapPacketCodecBukkit extends VideoMapPacketCodec {
 	 * @return packet to send to players
 	 */
 	public VideoMapPacket beginPlaybackImageBukkit(String url) {
-		return new VideoMapPacket(beginPlayback(url, loop, duration));
+		return new VideoMapPacket(beginPlayback(url));
 	}
 
 	/**

--- a/src/lwjgl/java/net/lax1dude/eaglercraft/adapter/EaglerAdapterImpl2.java
+++ b/src/lwjgl/java/net/lax1dude/eaglercraft/adapter/EaglerAdapterImpl2.java
@@ -675,6 +675,43 @@ public class EaglerAdapterImpl2 {
 		throw new UnsupportedOperationException("Video is not supported in LWJGL runtime");
 	}
 
+	public static final boolean isImageSupported() {
+		return false;
+	}
+	public static final void loadImage(String src) {
+		throw new UnsupportedOperationException("Image is not supported in LWJGL runtime");
+	}
+	public static final void loadImage(String src, String setJavascriptPointer) {
+		throw new UnsupportedOperationException("Image is not supported in LWJGL runtime");
+	}
+	public static final void loadImage(String src, String setJavascriptPointer, String javascriptOnloadFunction) {
+		throw new UnsupportedOperationException("Image is not supported in LWJGL runtime");
+	}
+	public static final void bufferImage(String src, int ttl) {
+		throw new UnsupportedOperationException("Image is not supported in LWJGL runtime");
+	}
+	public static final void unloadImage() {
+		throw new UnsupportedOperationException("Image is not supported in LWJGL runtime");
+	}
+	public static final boolean isImageLoaded() {
+		throw new UnsupportedOperationException("Image is not supported in LWJGL runtime");
+	}
+	public static final void updateImageTexture() {
+		throw new UnsupportedOperationException("Image is not supported in LWJGL runtime");
+	}
+	public static final void bindImageTexture() {
+		throw new UnsupportedOperationException("Image is not supported in LWJGL runtime");
+	}
+	public static final int getImageWidth() {
+		throw new UnsupportedOperationException("Image is not supported in LWJGL runtime");
+	}
+	public static final int getImageHeight() {
+		throw new UnsupportedOperationException("Image is not supported in LWJGL runtime");
+	}
+	public static final void setImageFrameRate(float seconds) {
+		throw new UnsupportedOperationException("Image is not supported in LWJGL runtime");
+	}
+
 	// =======================================================================================
 	// =======================================================================================
 	// =======================================================================================

--- a/src/main/java/net/minecraft/src/MapData.java
+++ b/src/main/java/net/minecraft/src/MapData.java
@@ -1,6 +1,5 @@
 package net.minecraft.src;
 
-import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/net/minecraft/src/MapItemRenderer.java
+++ b/src/main/java/net/minecraft/src/MapItemRenderer.java
@@ -42,6 +42,7 @@ public class MapItemRenderer {
 			texX2 = par3MapData.videoX2;
 			texY2 = par3MapData.videoY2;
 		}else if(isImageMode) {
+			EaglerAdapter.glEnable(EaglerAdapter.EAG_SWAP_RB);
 			EaglerAdapter.updateImageTexture();
 			EaglerAdapter.bindImageTexture();
 			texX1 = par3MapData.videoX1;
@@ -107,7 +108,7 @@ public class MapItemRenderer {
 		EaglerAdapter.glDisable(EaglerAdapter.GL_BLEND);
 		par2RenderEngine.resetBoundTexture();
 
-		if(isVideoMode) {
+		if(isVideoMode || isImageMode) {
 			EaglerAdapter.glDisable(EaglerAdapter.EAG_SWAP_RB);
 		}
 

--- a/src/main/java/net/minecraft/src/MapItemRenderer.java
+++ b/src/main/java/net/minecraft/src/MapItemRenderer.java
@@ -30,11 +30,20 @@ public class MapItemRenderer {
 		float texX2 = 1.0f;
 		float texY1 = 0.0f;
 		float texY2 = 1.0f;
-		boolean isVideoMode = EaglerAdapter.isVideoSupported() && par3MapData.enableVideoPlayback && EaglerAdapter.isVideoLoaded();
+		boolean isVideoOrImageMode = EaglerAdapter.isVideoSupported() && par3MapData.enableVideoPlayback;
+		boolean isVideoMode = isVideoOrImageMode && EaglerAdapter.isVideoLoaded();
+		boolean isImageMode = isVideoOrImageMode && EaglerAdapter.isImageLoaded();
 		if(isVideoMode) {
 			EaglerAdapter.glEnable(EaglerAdapter.EAG_SWAP_RB);
 			EaglerAdapter.updateVideoTexture();
 			EaglerAdapter.bindVideoTexture();
+			texX1 = par3MapData.videoX1;
+			texY1 = par3MapData.videoY1;
+			texX2 = par3MapData.videoX2;
+			texY2 = par3MapData.videoY2;
+		}else if(isImageMode) {
+			EaglerAdapter.updateImageTexture();
+			EaglerAdapter.bindImageTexture();
 			texX1 = par3MapData.videoX1;
 			texY1 = par3MapData.videoY1;
 			texX2 = par3MapData.videoX2;
@@ -45,26 +54,26 @@ public class MapItemRenderer {
 			}else {
 				for (int var4 = 0; var4 < 16384; ++var4) {
 					byte var5 = par3MapData.colors[var4];
-		
+
 					if (var5 / 4 == 0) {
 						this.intArray[var4] = (var4 + var4 / 128 & 1) * 8 + 16 << 24;
 					} else {
 						int var6 = MapColor.mapColorArray[var5 / 4].colorValue;
 						int var7 = var5 & 3;
 						short var8 = 220;
-		
+
 						if (var7 == 2) {
 							var8 = 255;
 						}
-		
+
 						if (var7 == 0) {
 							var8 = 180;
 						}
-		
+
 						int var9 = (var6 >> 16 & 255) * var8 / 255;
 						int var10 = (var6 >> 8 & 255) * var8 / 255;
 						int var11 = (var6 & 255) * var8 / 255;
-		
+
 						if (this.gameSettings.anaglyph) {
 							int var12 = (var9 * 30 + var10 * 59 + var11 * 11) / 100;
 							int var13 = (var9 * 30 + var10 * 70) / 100;
@@ -73,14 +82,14 @@ public class MapItemRenderer {
 							var10 = var13;
 							var11 = var14;
 						}
-		
+
 						this.intArray[var4] = -16777216 | var9 << 16 | var10 << 8 | var11;
 					}
 				}
 			}
 			par2RenderEngine.createTextureFromBytes(this.intArray, 128, 128, this.bufferedImage);
 		}
-		
+
 		byte var15 = 0;
 		byte var16 = 0;
 		Tessellator var17 = Tessellator.instance;
@@ -97,15 +106,15 @@ public class MapItemRenderer {
 		EaglerAdapter.glEnable(EaglerAdapter.GL_ALPHA_TEST);
 		EaglerAdapter.glDisable(EaglerAdapter.GL_BLEND);
 		par2RenderEngine.resetBoundTexture();
-		
+
 		if(isVideoMode) {
 			EaglerAdapter.glDisable(EaglerAdapter.EAG_SWAP_RB);
 		}
-		
+
 		if(!par3MapData.enableAyunami && !isVideoMode) {
 			mapicons.bindTexture();
 			int var19 = 0;
-	
+
 			for (Iterator var20 = par3MapData.playersVisibleOnMap.values().iterator(); var20.hasNext(); ++var19) {
 				MapCoord var21 = (MapCoord) var20.next();
 				EaglerAdapter.glPushMatrix();

--- a/src/main/java/net/minecraft/src/MapItemRenderer.java
+++ b/src/main/java/net/minecraft/src/MapItemRenderer.java
@@ -112,7 +112,7 @@ public class MapItemRenderer {
 			EaglerAdapter.glDisable(EaglerAdapter.EAG_SWAP_RB);
 		}
 
-		if(!par3MapData.enableAyunami && !isVideoMode) {
+		if(!par3MapData.enableAyunami && !(isVideoMode || isImageMode)) {
 			mapicons.bindTexture();
 			int var19 = 0;
 

--- a/src/main/java/net/minecraft/src/NetClientHandler.java
+++ b/src/main/java/net/minecraft/src/NetClientHandler.java
@@ -1017,6 +1017,8 @@ public class NetClientHandler extends NetHandler {
 			ItemMap.readAyunamiMapPacket(this.mc.theWorld, par1Packet131MapData.uniqueID, par1Packet131MapData.itemData);
 		} else if (par1Packet131MapData.itemID == 104) {
 			ItemMap.processVideoMap(this.mc.theWorld, par1Packet131MapData.itemData);
+		} else if (par1Packet131MapData.itemID == 105) {
+			ItemMap.processImageMap(this.mc.theWorld, par1Packet131MapData.itemData);
 		} else {
 			System.err.println("Unknown itemid: " + par1Packet131MapData.itemID);
 		}


### PR DESCRIPTION
This adds image element support to map items. This includes animated images, including GIFs and MJPEGs, in addition to static images like JPEGs and PNGs. It is quite straightforward; it simply uses the same packet format that the video packets use and ignores video-specific fields like audio, position, duration, and time. Thus, this may not be the best implementation, as it keeps unnecessary fields, but this does not affect performance or anything else. Feel free to optimize the way that the packets are sent.

In addition, I made the video map packet default to half volume because full volume is kinda really loud. It's up to you to keep this preference change, it can be put back.

Also please take a look at the sample packets, I am not really happy with what I changed with them but I'm not sure what to change to make them better. Something about how easy it is to switch between image and video mode. Let me know what you think it should look like.

**EDIT:** Just tested GIFs, they do NOT animate...but MJPEGs do, and since videos already work I do not think this is a big deal. MJPEGs are good for real-time low-latency (<=1sec) streaming, which is the primary reason why I added this. If GIF support is to be added, it may be more complex. After a quick search, it seems that web apis suck and it doesn't forward anything but the first gif frame... If we REALLY wanted GIFs, we would have to use an api such as https://github.com/matt-way/gifuct-js but I do not see the point of putting all that effort into it if the equivalent can be done with a video instead.