### PR TITLE
Fix critical bug in Bungee auth system

### DIFF
--- a/eaglercraftbungee/src/main/java/net/md_5/bungee/eaglercraft/AuthSystem.java
+++ b/eaglercraftbungee/src/main/java/net/md_5/bungee/eaglercraft/AuthSystem.java
@@ -51,6 +51,7 @@ public class AuthSystem {
 	private final Map<String, AuthData> database = new HashMap<>();
 
 	public boolean register(String username, String password, String ip) {
+		username = username.toLowerCase();
 		synchronized (database) {
 			AuthData authData = database.get(username);
 			if (authData != null)
@@ -66,12 +67,14 @@ public class AuthSystem {
 	}
 
 	public boolean isRegistered(String username) {
+		username = username.toLowerCase();
 		synchronized (database) {
 			return database.containsKey(username);
 		}
 	}
 
 	public boolean changePass(String username, String password) {
+		username = username.toLowerCase();
 		synchronized (database) {
 			AuthData authData = database.get(username);
 			authData.salt = createSalt(16);
@@ -82,6 +85,7 @@ public class AuthSystem {
 	}
 
 	public boolean login(String username, String password) {
+		username = username.toLowerCase();
 		synchronized (database) {
 			AuthData authData = database.get(username);
 			if (authData == null)


### PR DESCRIPTION
This PR fixes a critical issue in ayunami's auth system that allows authentication bypass by changing the case of the username, for example, if somebody registered "LAX1DUDE", somebody could login as "LaX1DUDE" and it would allow them register.

If the target server was also using CraftBukkit 1.5.2, this would allow them to bypass authentication and give them operator status.